### PR TITLE
basic wrapper lib

### DIFF
--- a/desk/app/nimi.hoon
+++ b/desk/app/nimi.hoon
@@ -163,6 +163,16 @@
                 uri.act
                 ship=?:(ship.act `our.bowl ~)
     ==  ==  ==
+    ::    
+      %find-ships
+    ?>  =(our.bowl src.bowl)
+    =/  pokes 
+    %+  turn  ships.act
+    |=  =ship
+    [%pass /whodis %agent [ship %nimi] %poke %nimi-action !>([%whodis ship])]
+    ::
+    :_  state
+    pokes
   ==
 ::
 ++  handle-wallet-update
@@ -202,8 +212,7 @@
   |=  =path
   ^-  (unit (unit cage))
   ?+    path  ~|("unexpected scry into {<dap.bowl>} on path {<path>}" !!)
-    [%x %username @ ~]
-    ~&  "full path: {<path>}"
+      [%x %username @ ~]
     =/  username  (slav %tas i.t.t.path)
     =+  lookupitem=(hash-data:smart minter-contract uqnames 0x0 username)
     =/  up
@@ -211,12 +220,26 @@
         (scot %p our.bowl)  %uqbar  (scot %da now.bowl)
         /indexer/newest/item/(scot %ux 0x0)/(scot %ux lookupitem)/noun
       ==
+    ?~  up  ``noun+!>(`noun`[%nouser ~])
     ?>  ?=(%newest-item -.up)
     =+  item=item.up
     ?>  ?=(%.y -.item)
     ::
     =/  data  ;;([@ux (unit @p)] noun.p.item)
     ::  empty @p?
-    ``noun+!>(`noun`[%username data])
-  ==  
+    ``noun+!>(`noun`data)
+  :: 
+      [%x %ship @ ~]
+    =/  ship  (slav %p i.t.t.path)
+    =/  user  (~(get by niccbook) ship)
+    ``noun+!>(`noun`user)
+    ::
+      [%x %ships @ ~]
+    =+  ships=;;((list @p) (cue (slav %ud i.t.t.path))) 
+    =/  users 
+      %+  turn  ships
+      |=  =ship
+      [ship (~(get by niccbook) ship)]
+    ``noun+!>(`noun`users)
+  ==
 --

--- a/desk/lib/nimi.hoon
+++ b/desk/lib/nimi.hoon
@@ -1,0 +1,55 @@
+::  lib wrapper to access usernames
+::  
+::
+::  todo revise bowl necessities => move into wrapper agent/core  
+|% 
+  +$  profile        [name=@t uri=@t address=@ux item=@ux sig=(unit [@ @ @])]
+  ::
+  ++  wrap-ship
+  |=  [=ship our=@p now=@da]
+  ::  ^-  [@p (unit profile)]
+  =/  up  .^  *  %gx
+        (scot %p our)  %nimi  (scot %da now)
+        /ship/(scot %p ship)/noun
+      ==
+  ::
+  ?~  up  [ship ~]
+  =/  prof  ;;((unit profile) up)
+  ?~  prof  [ship ~]
+  [ship prof]
+  ::
+  ++  wrap-ships
+  |=  [ships=(list ship) our=@p now=@da]
+  ::
+  =/  up  .^  *  %gx
+        (scot %p our)  %nimi  (scot %da now)
+        /ships/(scot %ud (jam ships))/noun
+      ==
+  ::
+  ?~  up  [~ ships]
+  =/  users  ;;((list [ship (unit profile)]) up)
+  ::
+  =/  unknown
+    %+  murn  users
+    |=  [=ship us=(unit profile)]
+    ?~  us  `ship
+    ~
+  [users unknown]
+  ::
+  ++  enjs-username
+    |=  [=ship our=@p now=@da]
+    =+  user=+:(wrap-ship ship our now)
+    ?~  user  ~
+    (scot %t name.u.user)
+  ::
+  ++  enjs-userpic
+    |=  [=ship our=@p now=@da]
+    =+  user=+:(wrap-ship ship our now)
+    ?~  user  ~
+    (scot %t uri.u.user)
+  ::
+  ::  then in %pongo or %pokur we could import /+  nimi
+  ::  then when passing change wrap ships with =/  [users unknown]  (wrap-ships:lib ships our.bowl now.bowl)
+  ::  and then also [%pass /find-ships [our.bowl %nimi] %poke %nimi-action !>([%find-ships unknown])]
+  ::  mayb...
+--

--- a/desk/mar/nimi/action.hoon
+++ b/desk/mar/nimi/action.hoon
@@ -1,0 +1,15 @@
+/-  *nimi
+::
+|_  act=action
+++  grab
+  |%
+  ++  noun  action
+  --
+::
+++  grow
+  |%
+  ++  noun  act
+  --
+::
+++  grad  %noun
+--

--- a/desk/sur/nimi.hoon
+++ b/desk/sur/nimi.hoon
@@ -17,6 +17,7 @@
     [%mint name=@t uri=@t nft=@ux address=@ux ship=?]
     [%set-profile item=@ux address=@ux]
     [%sign-ship address=@ux]
+    [%find-ships ships=(list ship)]
   ==
 ::
 +$  sig  [v=@ r=@ s=@]

--- a/desk/sur/zig/wallet.hoon
+++ b/desk/sur/zig/wallet.hoon
@@ -133,7 +133,7 @@
       [%derive-new-address hdpath=tape nick=@t]
       [%delete-address address=@ux]
       [%edit-nickname address=@ux nick=@t]
-      [%sign-typed-message from=address:smart domain=id:smart type=json msg=*]
+      [%sign-typed-message =origin from=address:smart domain=id:smart type=json msg=*]
       [%add-tracked-address address=@ux nick=@t]
       [%set-share-prefs =share-prefs]
       ::  testing and internal


### PR DESCRIPTION
this is one of several ways to do this.

we want several agents, say %pongo and %pokur, to easily interact with the username agent and wrap their ships into usernames, or query usernames for ships/addresses.

few ways to do this:
- origin pokebacks & scries. drawback: pokebacks are tedious and often create the need for pending state.
- wrapper agent: will explore in another pr, one downside is separated state for every integrating agent (fixable)
- clay noun file, wrapped by lib. downside, clay. 
- remote scry + pokes. <- good but still need local cache state.
- basic lib, does scries and returns ships, downside is poke to agent for unknown ships needs to be done by integrating agent.

this pr is the last option